### PR TITLE
feature(workflow): add issue manager workflow

### DIFF
--- a/.github/workflows/workflows-gh-manager.yaml
+++ b/.github/workflows/workflows-gh-manager.yaml
@@ -1,0 +1,22 @@
+name: Workflow issue manager
+
+on:
+  issues:
+    types: [opened, edited, closed, reopened, assigned, unassigned]
+
+jobs:
+  issue_handler:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log issue event
+        run: |
+          echo "Issue ${{ github.event.action }} by ${{ github.actor }}"
+          echo "Issue title: ${{ github.event.issue.title }}"
+          echo "Issue number: ${{ github.event.issue.number }}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to manage issues. The workflow is triggered by various issue events such as opening, editing, closing, reopening, assigning, and unassigning issues.

Key changes:

* Added a new workflow configuration file `.github/workflows/workflows-gh-manager.yaml` to handle issue events.
* The workflow, named "Workflow issue manager," runs on `ubuntu-latest` and has permissions to write to issues and read repository contents.
* The workflow includes steps to check out the repository and log the issue event details, such as the action, actor, issue title, and issue number.